### PR TITLE
Fix numpy errors

### DIFF
--- a/adopy/functions/_grid.py
+++ b/adopy/functions/_grid.py
@@ -61,7 +61,7 @@ def make_grid_matrix(axes_dict: Dict[GK, GV],
             labels.extend(k)
 
         # Make a grid as a 2d matrix
-        g_2d = np.reshape(g, (-1, 1)) if n_d_each[i] == 1 else g
+        g_2d = np.reshape(g, (-1, 1)) if n_d_each[i] == 1 else np.array(g)
 
         # Convert to a given dtype
         g_2d = g_2d.astype(dtype)

--- a/adopy/functions/_utils.py
+++ b/adopy/functions/_utils.py
@@ -64,4 +64,4 @@ def expand_multiple_dims(x: np.ndarray, pre: int, post: int) -> np.ndarray:
 def make_vector_shape(n: int, axis: int = 0) -> np.ndarray:
     ret = np.ones(n)
     ret[axis] = -1
-    return ret.astype(np.int)
+    return ret.astype(np.integer)

--- a/adopy/tasks/psi.py
+++ b/adopy/tasks/psi.py
@@ -225,7 +225,7 @@ class EnginePsi(Engine):
 
     @d_step.setter
     def d_step(self, value: integer_like):
-        if not isinstance(value, (int, np.int)) or value <= 0:
+        if not isinstance(value, (int, np.integer)) or value <= 0:
             raise ValueError('d_step should be an positive integer.')
         self._d_step = int(value)
 
@@ -272,7 +272,7 @@ class EnginePsi(Engine):
                 idx = min(len(self.grid_design) - 1,
                           self.idx_opt + (self.d_step * 2))
 
-            ret = self.grid_design.iloc[np.int(idx)]
+            ret = self.grid_design.iloc[np.integer(idx)]
 
         elif kind == 'random':
             idx = np.random.randint(self.n_d)

--- a/adopy/types.py
+++ b/adopy/types.py
@@ -17,15 +17,15 @@ data_like = TypeVar(
 integer_like = TypeVar(
     'integer_like',
     int,
-    np.int
+    np.integer
 )
 
 number_like = TypeVar(
     'number_like',
     float,
     int,
-    np.float,
-    np.int
+    np.floating,
+    np.integer
 )
 
 array_like = TypeVar(


### PR DESCRIPTION
## Changes

26917b05cce0fab13f91fc783631ef84aac0c33b

- This fixes a `AttributeError: 'list' object has no attribute 'astype'` error.

1bf3a949709bc4de4242318bbb1419f18928afde

- This fixes a `AttributeError: module 'numpy' has no attribute 'int'` error.
- `int`, `float` types were removed in current Numpy versions, and they were already deprecated in Numpy 1.20.
- I replaced them with abstract classes `integer` and `floating`.
- This change won't break any backward compatibility, since `integer` and `floating` data types have been present since the early versions of the library.

## References

- [Numpy Document - integer](https://numpy.org/devdocs/reference/arrays.scalars.html#numpy.integer)
- [Numpy Document - floating](https://numpy.org/devdocs/reference/arrays.scalars.html#numpy.floating)