### PR TITLE
Deploy docs via github pages

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -1,0 +1,45 @@
+name: Deploy Documentation website
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+    paths:
+      - 'docs/source/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out the repository
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.12'
+
+    - name: Install Poetry
+      run: |
+        curl -sSL https://install.python-poetry.org | python3 -
+        export PATH="$HOME/.poetry/bin:$PATH"
+        poetry config virtualenvs.create false
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get install pandoc
+        poetry install --extras "docs"
+
+    - name: Build the documentation
+      run: |
+        cd docs
+        make html
+
+    - name: Deploy to GitHub Pages
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        branch: docs
+        folder: docs/build/html
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,7 +36,7 @@ release = adopy.__version__
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-# needs_sphinx = '1.0'
+needs_sphinx = '8.0'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -67,7 +67,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -202,8 +202,8 @@ napoleon_use_rtype = False
 
 
 def setup(app):
-    app.add_stylesheet('css/custom.css')
-    app.add_javascript('js/custom.js')
+    app.add_css_file('css/custom.css')
+    app.add_js_file('js/custom.js')
 
 
 # Sphinx-issues settings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ docs = [
 [[tool.poetry.source]]
 name = "test"
 url = "https://test.pypi.org/legacy/"
-secondary = true
+priority = "supplemental"
 
 [build-system]
 requires = ["poetry>=0.12", "wheel"]


### PR DESCRIPTION
Currently we have uploaded the static files directly to `doc` branch.

This PR will set up a Github action that will automatically deploy the [adopy.github.io/adopy](https://adopy.github.io/adopy/) website, whenever there's a change in the `docs` directory in `develop` or `master` branches.

Merge it if this is deemed necessary.