### PR TITLE
Fix NumPy integer dtype compatibility

### DIFF
--- a/adopy/functions/_utils.py
+++ b/adopy/functions/_utils.py
@@ -64,4 +64,4 @@ def expand_multiple_dims(x: np.ndarray, pre: int, post: int) -> np.ndarray:
 def make_vector_shape(n: int, axis: int = 0) -> np.ndarray:
     ret = np.ones(n)
     ret[axis] = -1
-    return ret.astype(np.integer)
+    return ret.astype(int)

--- a/adopy/tasks/psi.py
+++ b/adopy/tasks/psi.py
@@ -272,7 +272,7 @@ class EnginePsi(Engine):
                 idx = min(len(self.grid_design) - 1,
                           self.idx_opt + (self.d_step * 2))
 
-            ret = self.grid_design.iloc[np.integer(idx)]
+            ret = self.grid_design.iloc[int(idx)]
 
         elif kind == 'random':
             idx = np.random.randint(self.n_d)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,3 +1,5 @@
+import importlib
+
 from collections import OrderedDict
 
 import numpy as np
@@ -7,6 +9,20 @@ from scipy.special import expit as inv_logit
 from scipy.stats import bernoulli
 
 from adopy import Engine, Model, Task
+
+
+def test_import_types_without_removed_numpy_scalar_aliases(monkeypatch):
+    # Regression for GH-31: importing ADOpy must not require np.int/np.float.
+    monkeypatch.delattr(np, 'int', raising=False)
+    monkeypatch.delattr(np, 'float', raising=False)
+
+    import adopy.types as adopy_types
+
+    reloaded_types = importlib.reload(adopy_types)
+
+    assert reloaded_types.integer_like.__constraints__ == (int, np.integer)
+    assert reloaded_types.number_like.__constraints__ == (
+        float, int, np.floating, np.integer)
 
 
 @pytest.fixture()

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -2,7 +2,8 @@ import numpy as np
 import pytest
 
 from adopy.functions import (
-    expand_multiple_dims, get_nearest_grid_index, marginalize,
+    expand_multiple_dims, get_nearest_grid_index, make_vector_shape,
+    marginalize,
 )
 
 
@@ -35,6 +36,12 @@ def test_expand_multiple_dims():
 
     assert expand_multiple_dims(y, 3, 2).shape == (1, 1, 1, 3, 4, 1, 1)
 
+
+def test_make_vector_shape_uses_integer_dtype():
+    shape = make_vector_shape(3, 1)
+
+    assert shape.tolist() == [1, -1, 1]
+    assert np.issubdtype(shape.dtype, np.integer)
 
 if __name__ == '__main__':
     pytest.main()


### PR DESCRIPTION
## Summary
- Replace deprecated/invalid `np.integer` runtime usage with plain `int` conversion.
- Add regression coverage for importing ADOpy without removed NumPy scalar aliases.
- Add a regression test for `make_vector_shape()` returning integer-shaped arrays.

## Why
Issue #31 reported an import-time failure from removed NumPy scalar aliases (`np.int` / `np.float`). Newer NumPy versions also no longer allow `np.integer` as a concrete dtype conversion target or scalar constructor. Together, these broke import/grid compatibility under current NumPy releases.

## Details
- `tests/test_base.py` reloads `adopy.types` after removing `np.int` and `np.float` from the NumPy module, guarding the import path from regressing.
- `make_vector_shape()` now casts with `int` instead of `np.integer`.
- `EnginePsi.get_design('staircase')` now indexes with `int(idx)` instead of constructing `np.integer(idx)`.
- `tests/test_functions.py` now covers the shape values and integer dtype invariant.

## Verification
- `uv run pytest tests/test_base.py tests/test_functions.py` -> 12 passed, 1 warning.

Closes #31

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>