### PR TITLE
Add project agent harness

### DIFF
--- a/.agents/skills/adopy-core-numerics/SKILL.md
+++ b/.agents/skills/adopy-core-numerics/SKILL.md
@@ -5,15 +5,12 @@ description: Use when changing ADOpy core Task/Model/Engine behavior, grid utili
 
 # ADOpy Core Numerics
 
-Use this skill before editing:
+Use this skill before editing core design-selection or numerical surfaces:
 
-- `adopy/base/_task.py`
-- `adopy/base/_model.py`
-- `adopy/base/_engine.py`
-- `adopy/functions/_grid.py`
-- `adopy/functions/_utils.py`
-- `adopy/functions/_const.py`
-- `adopy/types.py`
+- task, model, and engine classes under `adopy/base/`
+- grid, utility, constant, and type helpers under `adopy/functions/` and `adopy/types.py`
+
+Inspect the package tree for the current file inventory. Keep this skill focused on durable invariants rather than a complete list of filenames.
 
 ## Contract to preserve
 

--- a/.agents/skills/adopy-core-numerics/SKILL.md
+++ b/.agents/skills/adopy-core-numerics/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: adopy-core-numerics
+description: Use when changing ADOpy core Task/Model/Engine behavior, grid utilities, posterior updates, entropy, mutual information, dtype, random design selection, or numerical performance.
+---
+
+# ADOpy Core Numerics
+
+Use this skill before editing:
+
+- `adopy/base/_task.py`
+- `adopy/base/_model.py`
+- `adopy/base/_engine.py`
+- `adopy/functions/_grid.py`
+- `adopy/functions/_utils.py`
+- `adopy/functions/_const.py`
+- `adopy/types.py`
+
+## Contract to preserve
+
+- `Task` stores labels for design variables and response variables.
+- `Model` stores a `Task`, parameter labels, and an optional log-likelihood function.
+- `Model.compute()` returns log likelihood. It must not silently return probability-space values for real models.
+- `Engine` builds design, parameter, and response grids; computes likelihood tables; updates log posterior; and chooses designs by mutual information.
+- Posterior updates must remain normalized in log space.
+- `dtype` defaults to `numpy.float32`.
+
+## Workflow
+
+1. Identify the exact mathematical or API invariant being changed.
+2. Inspect current tests and docs for that invariant before editing.
+3. Keep computations vectorized with NumPy/Pandas/SciPy; avoid Python loops over full grid products unless the grid is explicitly tiny.
+4. Keep probability-sensitive operations in log space. Use `logsumexp` where normalization or marginalization requires it.
+5. Check memory shape before adding or expanding lookup tables. Grid-based ADO scales poorly with extra dimensions.
+6. Add or update the narrow test that would fail for the bug or behavior change.
+
+## Red flags
+
+Stop and re-check the math if a change touches:
+
+- `self._log_lik`, `self._marg_log_lik`, `self._ent`, `self._ent_marg`, `self._ent_cond`, or `self._mutual_info`
+- `noise_ratio`
+- response-grid indexing
+- tuple-key grids in `make_grid_matrix`
+- random selection from `np.random`
+- conversion between DataFrame, Series, ndarray, dict, and OrderedDict
+- dtype casts
+
+## Verification
+
+Run the narrowest relevant command:
+
+```bash
+uv run --extra test pytest tests/test_base.py
+uv run --extra test pytest tests/test_functions.py
+```
+
+If behavior depends on a task module, also run that task's test file. For random paths, seed or assert invariants instead of exact sampled values.

--- a/.agents/skills/adopy-docs-release/SKILL.md
+++ b/.agents/skills/adopy-docs-release/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: adopy-docs-release
+description: Use when changing ADOpy README, Sphinx docs, examples, changelog, version metadata, packaging, CI, or release instructions.
+---
+
+# ADOpy Docs and Release Surface
+
+Use this skill before editing:
+
+- `README.md`
+- `docs/source/**`
+- `pyproject.toml`
+- `setup.cfg`
+- `MANIFEST.in`
+- `.readthedocs.yml`
+- `.travis.yml` or replacement CI files
+- version or changelog surfaces
+
+## Current surfaces
+
+Sphinx docs live under `docs/source/`, API pages mirror package modules, and
+Read the Docs uses `docs/source/conf.py`. Before docs or release work, check
+`TODOS.md` for known documentation/release drift that should be fixed rather
+than copied into new guidance.
+
+## Documentation rules
+
+- Use current post-0.4.0 API names: `responses`, `params`, `grid_design`, `grid_param`, and `grid_response`.
+- Avoid deprecated example arguments such as `designs=`, `params=`, `param=`, `design=`, or `y_obs=` unless documenting migration history.
+- Verify module names against source before documenting imports.
+- Keep citations and package-version guidance visible for scientific changes.
+- If docs describe a model equation or task workflow, check that source code and tests still match.
+
+## Release/change checklist
+
+For user-facing behavior changes, update together:
+
+- code docstrings
+- Sphinx API/example docs
+- tests
+- changelog
+- README if the public feature list or install/use pattern changes
+- version metadata if preparing a release
+
+For packaging changes, verify source distribution inclusion/exclusion and docs build requirements.
+
+## Verification
+
+Use the narrowest relevant checks:
+
+```bash
+uv run --extra test pytest tests
+cd docs && uv run --extra docs make html
+```
+
+If a full docs build is not practical, inspect the affected `.rst`/notebook source and the corresponding Python API signatures, then state the limitation explicitly.

--- a/.agents/skills/adopy-docs-release/SKILL.md
+++ b/.agents/skills/adopy-docs-release/SKILL.md
@@ -16,7 +16,7 @@ Inspect the repository for the current filenames before editing. This skill shou
 
 ## Documentation rules
 
-- Use current post-0.4.0 API names: `responses`, `params`, `grid_design`, `grid_param`, and `grid_response`.
+- Use the current API names: `responses`, `params`, `grid_design`, `grid_param`, and `grid_response`.
 - Avoid deprecated example arguments such as `designs=`, `params=`, `param=`, `design=`, or `y_obs=` unless documenting migration history.
 - Verify module names against source before documenting imports.
 - Keep citations and package-version guidance visible for scientific changes.

--- a/.agents/skills/adopy-docs-release/SKILL.md
+++ b/.agents/skills/adopy-docs-release/SKILL.md
@@ -5,23 +5,14 @@ description: Use when changing ADOpy README, Sphinx docs, examples, changelog, v
 
 # ADOpy Docs and Release Surface
 
-Use this skill before editing:
+Use this skill before editing documentation, release, or packaging surfaces such as:
 
 - `README.md`
-- `docs/source/**`
-- `pyproject.toml`
-- `setup.cfg`
-- `MANIFEST.in`
-- `.readthedocs.yml`
-- `.travis.yml` or replacement CI files
-- version or changelog surfaces
+- Sphinx docs and examples
+- package metadata and manifests
+- CI, Read the Docs, changelog, version, or release instructions
 
-## Current surfaces
-
-Sphinx docs live under `docs/source/`, API pages mirror package modules, and
-Read the Docs uses `docs/source/conf.py`. Before docs or release work, check
-`TODOS.md` for known documentation/release drift that should be fixed rather
-than copied into new guidance.
+Inspect the repository for the current filenames before editing. This skill should capture durable documentation/release rules, not a live inventory of every page, config file, or temporary drift item.
 
 ## Documentation rules
 

--- a/.agents/skills/adopy-task-model/SKILL.md
+++ b/.agents/skills/adopy-task-model/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: adopy-task-model
+description: Use when adding or modifying preimplemented ADOpy task, model, or task-specific engine modules under adopy/tasks.
+---
+
+# ADOpy Task and Model Modules
+
+Use this skill before editing `adopy/tasks/*.py` or adding a new preimplemented experimental task.
+
+## Existing task modules
+
+- `adopy.tasks.psi`: psychometric function estimation / 2AFC.
+- `adopy.tasks.dd`: delay discounting.
+- `adopy.tasks.cra`: choice under risk and ambiguity.
+
+Each module should keep the same triad:
+
+1. `Task*` class with design and response labels.
+2. One or more `Model*` classes with named model parameters and log-likelihood computation.
+3. `Engine*` wrapper that supplies task-specific defaults and validates model/task compatibility.
+
+## Implementation rules
+
+- Match design labels, response labels, parameter labels, likelihood-function arguments, grid keys, tests, and docs exactly.
+- Return log likelihoods from model computations. Use `scipy.stats.*.logpmf` or equivalent log-space computation.
+- Keep model names, parameter names, and equations aligned with source literature and module docstrings.
+- Do not change task defaults, response coding, or parameter semantics without updating tests and docs.
+- Do not expand ADOpy into participant-presentation or response-capture code. Keep experiment runtime code outside the package unless explicitly requested.
+- Keep grids small in tests. Tests should prove behavior and compatibility, not run publication-scale simulations.
+
+## Adding a new task
+
+A complete new task requires:
+
+- a new module under `adopy/tasks/`
+- a `Task*` class
+- at least one `Model*` class
+- an `Engine*` wrapper or explicit reason the base `Engine` is enough
+- a pytest file covering initialization, `get_design`, and `update`
+- a Sphinx API page under `docs/source/api/tasks/`
+- an entry in the docs index if users should discover it
+- citations or source notes for the experimental task and model equations
+
+## Verification
+
+Run the task-specific test file:
+
+```bash
+uv run --extra test pytest tests/test_psi.py
+uv run --extra test pytest tests/test_dd.py
+uv run --extra test pytest tests/test_cra.py
+```
+
+For a new task, add and run the corresponding new test file. If core engine assumptions change, also run `tests/test_base.py`.

--- a/.agents/skills/adopy-task-model/SKILL.md
+++ b/.agents/skills/adopy-task-model/SKILL.md
@@ -7,13 +7,11 @@ description: Use when adding or modifying preimplemented ADOpy task, model, or t
 
 Use this skill before editing `adopy/tasks/*.py` or adding a new preimplemented experimental task.
 
-## Existing task modules
+## Scope discovery
 
-- `adopy.tasks.psi`: psychometric function estimation / 2AFC.
-- `adopy.tasks.dd`: delay discounting.
-- `adopy.tasks.cra`: choice under risk and ambiguity.
+Inspect `adopy/tasks/`, matching tests, docs, and package exports to learn the current task inventory before editing. Do not encode the implemented task list in this skill; it changes as modules are added or removed.
 
-Each module should keep the same triad:
+Each task module should keep the same triad:
 
 1. `Task*` class with design and response labels.
 2. One or more `Model*` classes with named model parameters and log-likelihood computation.
@@ -43,12 +41,10 @@ A complete new task requires:
 
 ## Verification
 
-Run the task-specific test file:
+Choose verification from the module you touched:
 
 ```bash
-uv run --extra test pytest tests/test_psi.py
-uv run --extra test pytest tests/test_dd.py
-uv run --extra test pytest tests/test_cra.py
+uv run --extra test pytest tests/test_<task_module>.py
 ```
 
-For a new task, add and run the corresponding new test file. If core engine assumptions change, also run `tests/test_base.py`.
+For multiple task modules, run each matching test file. For a new task, add and run the corresponding new test file. If a task change affects base engine assumptions, also run `uv run --extra test pytest tests/test_base.py`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,13 +25,7 @@ The intended experiment loop is:
 
 ## Local harness
 
-Project-local reusable skills live under `.agents/skills/`:
-
-- `.agents/skills/adopy-core-numerics/SKILL.md`
-- `.agents/skills/adopy-task-model/SKILL.md`
-- `.agents/skills/adopy-docs-release/SKILL.md`
-
-Use the relevant skill before changing its target area.
+Project-local skills live under `.agents/skills/`; use the relevant one before editing its target area.
 
 ## API contract
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,12 +33,12 @@ Project-local reusable skills live under `.agents/skills/`:
 
 Use the relevant skill before changing its target area.
 
-## Post-0.4 API traps
+## API contract
 
 Preserve Python `>=3.6` compatibility unless the task explicitly authorizes
 modernization.
 
-Respect the post-0.4.0 API contract:
+Key non-obvious behavior to preserve:
 
 - `Task.responses` stores response-variable labels, not possible response
   values.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,105 @@
+# ADOpy Agent Instructions
+
+## What is not obvious from the code
+
+ADOpy is a scientific package for Adaptive Design Optimization (ADO) in
+behavioral experiments. Treat code changes as changes to experimental design,
+not as ordinary data-processing refactors. Small numerical edits can alter trial
+selection, posterior estimates, and published reproducibility.
+
+ADOpy's responsibility stops at design selection and Bayesian updating. It does
+not present stimuli, collect participant responses, save experiment data, or
+replace PsychoPy/OpenSesame/Expyriment-style experiment runtimes unless the user
+explicitly asks for an integration layer.
+
+The intended experiment loop is:
+
+1. Define a `Task`.
+2. Define a `Model`.
+3. Define design, parameter, and response grids.
+4. Initialize an `Engine`.
+5. Call `engine.get_design(...)`.
+6. Collect a participant or simulated response outside ADOpy.
+7. Call `engine.update(design, response)`.
+8. Repeat.
+
+## Local harness
+
+Project-local reusable skills live under `.agents/skills/`:
+
+- `.agents/skills/adopy-core-numerics/SKILL.md`
+- `.agents/skills/adopy-task-model/SKILL.md`
+- `.agents/skills/adopy-docs-release/SKILL.md`
+
+Use the relevant skill before changing its target area.
+
+## Post-0.4 API traps
+
+Preserve Python `>=3.6` compatibility unless the task explicitly authorizes
+modernization.
+
+Respect the post-0.4.0 API contract:
+
+- `Task.responses` stores response-variable labels, not possible response
+  values.
+- Possible response values belong in `Engine(..., grid_response=...)`.
+- `Model.func` and `Model.compute()` return log likelihoods, not binary-response
+  probabilities.
+- `Model.func` argument names must include every task design label, response
+  label, and model parameter label.
+- `Engine.update()` accepts one design/response pair or matched lists of pairs.
+- `Engine(dtype=...)` defaults to `numpy.float32`; changing dtype behavior is a
+  behavioral change.
+
+Do not add deprecated aliases, compatibility shims, or parallel APIs unless
+explicitly requested. Prefer clean migration of docs, tests, and callsites.
+
+## Numerical guardrails
+
+Be especially conservative around:
+
+- likelihood/log-likelihood semantics
+- posterior normalization
+- `scipy.special.logsumexp`
+- entropy, conditional entropy, marginal entropy, and mutual information
+- cached `Engine` fields beginning with `_log_lik`, `_marg_log_lik`, `_ent`,
+  `_ent_marg`, `_ent_cond`, or `_mutual_info`
+- grid construction and tuple-key multi-column grids
+- nearest-grid matching
+- random design paths
+- `noise_ratio`
+- dtype and precision
+- memory allocation from Cartesian grids or precomputed lookup tables
+
+Grid-based ADO has exponential memory pressure as design, parameter, or response
+dimensions grow. Do not casually increase default grid sizes or dimensionality.
+
+## Scientific references
+
+Use the project docs and papers as the conceptual anchor for scientific changes:
+
+- ADOpy docs: https://adopy.github.io/adopy/
+- ADOpy package paper: Yang, Pitt, Ahn, & Myung, Behavior Research Methods
+  53(2):874-897, DOI `10.3758/s13428-020-01386-4`
+- ADO tutorial: Myung, Cavagnaro, & Pitt, Journal of Mathematical Psychology
+  57:53-67, DOI `10.1016/j.jmp.2013.05.005`
+
+For task-specific models, keep terminology, parameter names, equations, and
+citations aligned with module docstrings and docs.
+
+## Verification expectations
+
+Run the narrowest meaningful verification for changed files:
+
+- `adopy/base/*` -> `uv run --extra test pytest tests/test_base.py`
+- `adopy/functions/*` -> `uv run --extra test pytest tests/test_functions.py`
+- `adopy/tasks/psi.py` -> `uv run --extra test pytest tests/test_psi.py`
+- `adopy/tasks/dd.py` -> `uv run --extra test pytest tests/test_dd.py`
+- `adopy/tasks/cra.py` -> `uv run --extra test pytest tests/test_cra.py`
+- Docs/API changes -> build or inspect the affected Sphinx page and verify
+  current API names.
+- Packaging/release changes -> verify version, changelog, README/docs, and
+  package metadata surfaces together.
+
+Prefer small deterministic tests over broad stochastic assertions. For random
+paths, assert invariants or seed the RNG.

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,15 @@
+# TODOs
+
+Temporary holding area for repository drift found while adding project agent support.
+
+## Documentation/API drift
+
+- Replace stale `adopy.tasks.ddt` mentions with implemented module name `adopy.tasks.dd` in README/docs.
+- Rewrite `docs/source/examples/psi.rst` to use the post-0.4 API (`responses`, `params`, `grid_design`, `grid_param`, `grid_response`) instead of deprecated example arguments.
+- Audit `docs/source/getting-started.rst` logistic example; `logit = b0 + x1 * b1 + x1 * b2` likely should use `x2 * b2` for the second design variable.
+
+## Release/package drift
+
+- Align version surfaces across local metadata, docs, package fallback version, and PyPI release notes.
+- Review `MANIFEST.in`; it includes `README.rst` even though the repository uses `README.md`.
+- Review old Travis/Gitflow/master-branch documentation against the current default branch and CI/deploy reality.


### PR DESCRIPTION
## Summary
- Add project-local agent guidance in `AGENTS.md`.
- Add three reusable `.agents/skills/` workflows for ADOpy-specific work:
  - `adopy-core-numerics`
  - `adopy-task-model`
  - `adopy-docs-release`
- Add `TODOS.md` for repository drift discovered during harness setup.

## Why
The harness captures project knowledge that is not obvious from reading individual source files: ADOpy's scientific/numerical risk boundaries, post-0.4 API traps, experiment-loop responsibilities, and verification expectations. Drift items are tracked separately so they are fixed deliberately instead of becoming permanent agent instructions.

## Details
- `AGENTS.md` focuses on non-obvious guidance: stimulus-selection scope, log-likelihood semantics, response-grid API boundaries, numerical guardrails, scientific references, and targeted verification commands.
- Skill files split reusable workflows by concern: core numerics, task/model modules, and docs/release surfaces.
- `TODOS.md` records documentation/API/release drift for follow-up cleanup.

## Verification
- Verified harness paths and skill frontmatter during setup.
- `uv run --extra test pytest tests` -> 61 passed.
- `uv build` -> built `dist/adopy-0.5.0.tar.gz` and `dist/adopy-0.5.0-py3-none-any.whl`.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>